### PR TITLE
Add support for configurable PDS URL

### DIFF
--- a/.changeset/tame-monkeys-argue.md
+++ b/.changeset/tame-monkeys-argue.md
@@ -1,0 +1,5 @@
+---
+"mcp-server-bluesky": minor
+---
+
+Add support for configurable PDS URL

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ MCP server for [Bluesky](https://bsky.app/).
       "env": {
         "BLUESKY_USERNAME": "username",
         "BLUESKY_PASSWORD": "password",
+        "BLUESKY_PDS_URL": "https://bsky.social"
       }
     }
   }
 }
 ```
+
+The `BLUESKY_PDS_URL` is optional and defaults to `https://bsky.social` if not specified.
 
 ## Tools
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { handleToolCall, tools } from "./tools/index.js";
 async function main() {
 	const identifier = process.env.BLUESKY_USERNAME;
 	const password = process.env.BLUESKY_PASSWORD;
+	const service = process.env.BLUESKY_PDS_URL || "https://bsky.social";
 
 	if (!identifier || !password) {
 		console.error(
@@ -22,7 +23,7 @@ async function main() {
 		process.exit(1);
 	}
 
-	const agent = new AtpAgent({ service: "https://bsky.social" });
+	const agent = new AtpAgent({ service });
 	const loginResponse = await agent.login({
 		identifier,
 		password,


### PR DESCRIPTION
Added an optional configuration parameter, which allows logging in to a self-hosted PDS with the MCP tool. The parameter looks like this:

"BLUESKY_PDS_URL": "https://artcru.sh"

or for a full config

    "bluesky": {
      "command": "node",
      "args": ["/Users/rob/repos/mcp-server-bluesky/dist/index.js"],
      "env": {
        "BLUESKY_USERNAME": "phr34ky.artcru.sh",
        "BLUESKY_PASSWORD": "YOUR ACCOUNT PASSWORD",
        "BLUESKY_PDS_URL": "https://artcru.sh"
      }
    }
    
Note this parameter is 100% optional and will not affect current users that are logging in to Bluesky and do not use this parameter.

Thanks so much for this super useful MCP server. I plan on adding in a few more things, will try to keep consistent style.